### PR TITLE
refactor: change flask-restful to flask-restplus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -r requirements.txt
 COPY ./entrypoint.sh /app/entrypoint.sh
 
 COPY ./server.py /app/server.py
-COPY ./ressources.py /app/ressources.py
+COPY ./api.py /app/api.py
 COPY ./page.py /app/page.py
 COPY ./conf /app/conf
 

--- a/api.py
+++ b/api.py
@@ -1,6 +1,16 @@
-from flask import session, request
-from flask_restful import Resource, Api
+from flask import session, request, Blueprint
+from flask_restplus import Api, Resource, fields
 
+api_version = 'v0.1'
+blueprint = Blueprint('api', __name__, url_prefix='/api/' + api_version)
+api = Api(blueprint,
+          version=api_version,
+          title='API La petite boite noire',
+          description='API for building games for "La petite boite noire"')
+
+
+
+@api.route('/user')
 class User(Resource):
     def get(self):
         return {'username': session['username']}
@@ -9,6 +19,7 @@ class User(Resource):
         session['username'] = request.form['username']
         return {'username': session['username']}
 
+@api.route('/score')
 class Score(Resource):
     def get(self):
         return {'privacy': session['privacy'], 'time': session['time']}
@@ -25,6 +36,7 @@ class Score(Resource):
 
         return {'privacy': session['privacy'], 'time': session['time']}
 
+@api.route('/gains')
 class Gains(Resource):
     def get(self):
         return session['gains']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.1
 gunicorn==19.9.0
-flask-restful==0.3.7
+flask-restplus==0.13.0
 toml==0.10.0

--- a/server.py
+++ b/server.py
@@ -1,17 +1,17 @@
 from flask import Flask, session, redirect
-from flask_restful import Api
+from flask_restplus import Api
 from random import choice
 import os
 
 import toml
 
-from ressources import Score, User, Gains
 from page import Page
 from conf.secrets import session_key
 
-app = Flask(__name__)
-api = Api(app)
+from api import blueprint
 
+app = Flask(__name__)
+app.register_blueprint(blueprint)
 app.secret_key = session_key
 
 with open('conf/config.toml') as f:
@@ -61,7 +61,3 @@ def end():
     session['gains'].append({'name': 'end', 'privacy': 0, 'time': 0})
     return page.content
 
-api_version = 'v0.1'
-api.add_resource(User, '/api/' + api_version + '/user')
-api.add_resource(Score, '/api/' + api_version + '/score')
-api.add_resource(Gains, '/api/' + api_version + '/gains')


### PR DESCRIPTION
The previous API library used, flask-restful, was not able to generate
documentation for openapi (swagger).

Therefore, the library used for the api have been changed to restplus,
which autoaticly serve the api documentation at the api root.